### PR TITLE
chore: Move PR template for outside

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,9 +1,0 @@
-## Title of what you did.
-
-* List of things you did
-*
-*
-*
-
-
-[ Photo (optional) ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Title of what you did.
+
+* List of things you did
+*
+*
+*
+
+
+[ Photo (optional) ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,10 @@
 ## Title of what you did.
 
+### Progress:
+
+ - [x] (Optional)
+ - [ ]
+
 * List of things you did
 *
 *


### PR DESCRIPTION
## Moví el `pr template` hacia la carpeta base de `.github`

Al parecer el template no funciono al estar en una carpeta dentro de la carpeta .github, y como solo se puede confirmar si funciona o no por medio de una PR tuve que abrir una nueva PR al darme cuenta que no funcionaba como se esperaba.