### PR TITLE
feat: Improve `messages` props handling

### DIFF
--- a/src/components/ImageMessage.tsx
+++ b/src/components/ImageMessage.tsx
@@ -1,11 +1,18 @@
 import {type FC} from "react"
-import MessageContainer, {type MessageBaseProps} from "./MessageContainer"
+import MessageContainer, {
+  type MessageBaseData,
+  type MessageBaseProps,
+} from "./MessageContainer"
 import {IoIosAlert} from "react-icons/io"
 import ContextMenu from "./ContextMenu"
 
 export interface ImageMessageProps extends MessageBaseProps {
   imageUrl?: string
   onClickImage: () => void
+}
+
+export interface ImageMessageData extends MessageBaseData {
+  imageUrl?: string
 }
 
 const ImageMessage: FC<ImageMessageProps> = ({
@@ -15,10 +22,9 @@ const ImageMessage: FC<ImageMessageProps> = ({
   imageUrl,
   onAuthorClick,
   onClickImage,
-  text,
   timestamp,
   contextMenuItems,
-  id,
+  messageId,
 }) => {
   const content = (
     <div className="flex flex-col pt-1">
@@ -33,14 +39,14 @@ const ImageMessage: FC<ImageMessageProps> = ({
       ) : (
         // TODO: Handle image size here. Preferably, make the component accept 'imageDimensions' as props.
         // TODO: Add keyboard event listener for accessibility.
-        <ContextMenu id={`image-menu-${id}`} elements={contextMenuItems}>
+        <ContextMenu id={`image-menu-${messageId}`} elements={contextMenuItems}>
           <button
             className="max-h-52 max-w-44 appearance-none overflow-hidden rounded-xl"
             onClick={onClickImage}>
             <img
               className="cursor-pointer object-contain"
               src={imageUrl}
-              alt={text}
+              alt={`Message by ${authorDisplayName}`}
             />
           </button>
         </ContextMenu>

--- a/src/components/ImageMessage.tsx
+++ b/src/components/ImageMessage.tsx
@@ -8,7 +8,7 @@ import ContextMenu from "./ContextMenu"
 
 export interface ImageMessageProps extends MessageBaseProps {
   imageUrl?: string
-  onClickImage: () => void
+  onClickImage: (imgUrl: string) => void
 }
 
 export interface ImageMessageData extends MessageBaseData {
@@ -28,7 +28,7 @@ const ImageMessage: FC<ImageMessageProps> = ({
 }) => {
   const content = (
     <div className="flex flex-col pt-1">
-      {imageUrl === null ? (
+      {imageUrl === undefined ? (
         <div className="flex flex-row items-center gap-1">
           <IoIosAlert className="text-red-500" />
 
@@ -42,7 +42,9 @@ const ImageMessage: FC<ImageMessageProps> = ({
         <ContextMenu id={`image-menu-${messageId}`} elements={contextMenuItems}>
           <button
             className="max-h-52 max-w-44 appearance-none overflow-hidden rounded-xl"
-            onClick={onClickImage}>
+            onClick={() => {
+              onClickImage(imageUrl)
+            }}>
             <img
               className="cursor-pointer object-contain"
               src={imageUrl}

--- a/src/components/MessageContainer.tsx
+++ b/src/components/MessageContainer.tsx
@@ -6,19 +6,28 @@ import Typography, {TypographyVariant} from "./Typography"
 import {type ContextMenuItem} from "./ContextMenu"
 
 export type MessageBaseProps = {
-  authorAvatarUrl?: string
   authorDisplayName: string
-  authorDisplayNameColor: string
+  authorDisplayNameColor?: string
+  authorAvatarUrl?: string
   timestamp: number
-  id: string
-  text: string
+  messageId: string
   contextMenuItems: ContextMenuItem[]
   onAuthorClick: () => void
 }
 
+export type MessageBaseData = {
+  authorDisplayName: string
+  authorDisplayNameColor?: string
+  authorAvatarUrl?: string
+  timestamp: number
+  messageId: string
+  isDeleted?: boolean
+  canDeleteMessage?: boolean
+}
+
 export type MessageContainerProps = {
   authorDisplayName: string
-  authorDisplayNameColor: string
+  authorDisplayNameColor?: string
   authorAvatarUrl?: string
   children: React.JSX.Element
   timestamp: number

--- a/src/components/TextMessage.tsx
+++ b/src/components/TextMessage.tsx
@@ -1,9 +1,21 @@
 import {type FC} from "react"
-import MessageContainer, {type MessageBaseProps} from "./MessageContainer"
+import MessageContainer, {
+  type MessageBaseData,
+  type MessageBaseProps,
+} from "./MessageContainer"
 import ContextMenu from "./ContextMenu"
 import Typography, {TypographyVariant} from "./Typography"
 
-const TextMessage: FC<MessageBaseProps> = ({
+export interface TextMessageProps extends MessageBaseProps {
+  text: string
+}
+
+export interface TextMessageData extends MessageBaseData {
+  text: string
+  isDeleted?: boolean
+}
+
+const TextMessage: FC<TextMessageProps> = ({
   authorAvatarUrl,
   authorDisplayName,
   authorDisplayNameColor,
@@ -11,7 +23,7 @@ const TextMessage: FC<MessageBaseProps> = ({
   text,
   timestamp,
   contextMenuItems,
-  id,
+  messageId,
 }) => {
   return (
     <MessageContainer
@@ -20,7 +32,7 @@ const TextMessage: FC<MessageBaseProps> = ({
       authorAvatarUrl={authorAvatarUrl}
       timestamp={timestamp}
       onAuthorClick={onAuthorClick}>
-      <ContextMenu id={`text-message-${id}`} elements={contextMenuItems}>
+      <ContextMenu id={`text-message-${messageId}`} elements={contextMenuItems}>
         <Typography
           className="max-w-messageMaxWidth cursor-text select-text break-words"
           variant={TypographyVariant.Body}>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,7 +1,7 @@
 import {type FC} from "react"
 import {assert, cleanDisplayName, trim, validateUrl} from "../utils/util"
 import {twMerge} from "tailwind-merge"
-import AvatarImage, {AvatarType} from "./AvatarImage"
+import AvatarImage, {AvatarSize, AvatarType} from "./AvatarImage"
 import React from "react"
 import Typography, {TypographyVariant} from "./Typography"
 
@@ -15,6 +15,8 @@ export type UserProfileProps = {
   isLarge?: boolean
   className?: string
 }
+
+// TODO: Fix with new `AvatarImage`
 
 const UserProfile: FC<UserProfileProps> = ({
   displayName,
@@ -43,7 +45,7 @@ const UserProfile: FC<UserProfileProps> = ({
     <div className={twMerge("flex gap-2", className)}>
       <AvatarImage
         isRounded={false}
-        isLarge={isLarge}
+        avatarSize={AvatarSize.Large}
         avatarType={avatarType}
         displayName={displayName}
         avatarUrl={avatarUrl}

--- a/src/containers/RoomContainer/ChatMessages.tsx
+++ b/src/containers/RoomContainer/ChatMessages.tsx
@@ -61,11 +61,9 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
           <ImageMessage
             key={message.data.messageId}
             {...message.data}
+            onClickImage={setImagePrevUrl}
             onAuthorClick={() => {
               throw new Error("Function not implemented.")
-            }}
-            onClickImage={() => {
-              setImagePrevUrl(message.data.imageUrl)
             }}
             contextMenuItems={buildMessageMenuItems({
               canDeleteMessage: message.data.canDeleteMessage === true,

--- a/src/containers/RoomContainer/ChatMessages.tsx
+++ b/src/containers/RoomContainer/ChatMessages.tsx
@@ -10,6 +10,7 @@ import {twMerge} from "tailwind-merge"
 import {type AnyMessage, MessageKind, MessagesState} from "./hooks/useRoomChat"
 import {createPortal} from "react-dom"
 import ImageModal from "./ImageModal"
+import {buildMessageMenuItems} from "@/utils/menu"
 
 export type ChatMessagesProps = {
   messages: AnyMessage[]
@@ -36,14 +37,53 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
     () =>
       messages.map(message =>
         message.kind === MessageKind.Text ? (
-          <TextMessage key={message.data.id} {...message.data} />
+          <TextMessage
+            key={message.data.messageId}
+            {...message.data}
+            contextMenuItems={buildMessageMenuItems({
+              isMessageError: message.data.isDeleted === true,
+              canDeleteMessage: message.data.canDeleteMessage === true,
+              onReplyMessage() {
+                // TODO: Handle reply
+              },
+              onResendMessage() {
+                // TODO: Handle resend message here.
+              },
+              onDeleteMessage() {
+                // deleteMessage(room.client, room.roomId, eventId)
+              },
+            })}
+            onAuthorClick={() => {
+              throw new Error("Function not implemented.")
+            }}
+          />
         ) : message.kind === MessageKind.Image ? (
           <ImageMessage
-            key={message.data.id}
+            key={message.data.messageId}
             {...message.data}
+            onAuthorClick={() => {
+              throw new Error("Function not implemented.")
+            }}
             onClickImage={() => {
               setImagePrevUrl(message.data.imageUrl)
             }}
+            contextMenuItems={buildMessageMenuItems({
+              canDeleteMessage: message.data.canDeleteMessage === true,
+              isMessageError: false,
+              isSaveable: true,
+              onReplyMessage() {
+                // TODO: Handle reply
+              },
+              onResendMessage() {
+                // TODO: Handle resend message here.
+              },
+              onSaveContent() {
+                // TODO: Handle image saving here.
+              },
+              onDeleteMessage() {
+                // deleteMessage(room.client, room.roomId, eventId)
+              },
+            })}
           />
         ) : message.kind === MessageKind.Event ? (
           <EventMessage

--- a/src/containers/RoomContainer/hooks/useRoomChat.tsx
+++ b/src/containers/RoomContainer/hooks/useRoomChat.tsx
@@ -1,6 +1,6 @@
 import {type EventMessageData} from "@/components/EventMessage"
-import {type ImageMessageProps} from "@/components/ImageMessage"
-import {type MessageBaseProps} from "@/components/MessageContainer"
+import {type ImageMessageData} from "@/components/ImageMessage"
+import {type TextMessageData} from "@/components/TextMessage"
 import {type TypingIndicatorUser} from "@/components/TypingIndicator"
 import {type UnreadIndicatorProps} from "@/components/UnreadIndicator"
 import useActiveRoomIdStore from "@/hooks/matrix/useActiveRoomIdStore"
@@ -28,9 +28,9 @@ export enum MessagesState {
 }
 
 export type MessageOf<Kind extends MessageKind> = Kind extends MessageKind.Text
-  ? MessageBaseProps
+  ? TextMessageData
   : Kind extends MessageKind.Image
-    ? ImageMessageProps
+    ? ImageMessageData
     : Kind extends MessageKind.Event
       ? EventMessageData
       : UnreadIndicatorProps
@@ -125,7 +125,7 @@ const useRoomChat = (roomId: string): UseRoomChatReturnType => {
       return
     }
 
-    void handleEvent(room.client, event, room).then(messageOrEvent => {
+    void handleEvent(event, room).then(messageOrEvent => {
       if (messageOrEvent === null) {
         return
       }

--- a/src/containers/Roster/RosterUser.tsx
+++ b/src/containers/Roster/RosterUser.tsx
@@ -5,18 +5,21 @@ import {twMerge} from "tailwind-merge"
 import Typography, {TypographyVariant} from "@/components/Typography"
 import {type UserPowerLevel} from "@/utils/members"
 
-export type RosterUserProps = {
+export type RosterUserData = {
   displayName: string
   powerLevel: UserPowerLevel
   userId: string
   lastPresenceAge?: number
   avatarUrl?: string
+}
+
+export interface RosterUserProps extends RosterUserData {
   className?: string
-  onClick: () => void
+  onUserClick: () => void
 }
 
 const RosterUser: FC<RosterUserProps> = ({
-  onClick,
+  onUserClick,
   lastPresenceAge,
   displayName,
   userId,
@@ -30,7 +33,7 @@ const RosterUser: FC<RosterUserProps> = ({
 
   return (
     <div
-      onClick={onClick}
+      onClick={onUserClick}
       className={twMerge(
         "w-full cursor-pointer p-1 hover:rounded-xl hover:bg-neutral-100 focus-visible:rounded-md focus-visible:border-2 focus-visible:border-blue-400 focus-visible:outline-none focus-visible:transition focus-visible:duration-150",
         className

--- a/src/hooks/matrix/useCreateRoom.ts
+++ b/src/hooks/matrix/useCreateRoom.ts
@@ -33,6 +33,7 @@ const useCreateRoom = (): UseCreateRoomReturnType => {
   const [roomDescription, setRoomDescription] = useState<string>()
   const [roomVisibility, setRoomVisibility] = useState(Visibility.Private)
   const [enableEncryption, setEnableEncryption] = useState(false)
+
   const [isCreatingRoom, setIsCreatingRoom] = useState(false)
   const {clearActiveModal} = useActiveModalStore()
   const {client} = useConnection()

--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -1,4 +1,4 @@
-import {type RosterUserProps} from "@/containers/Roster/RosterUser"
+import {type RosterUserData} from "@/containers/Roster/RosterUser"
 import {type Room, EventTimeline, EventType} from "matrix-js-sdk"
 import {getImageUrl, normalizeName} from "./util"
 import {ImageSizes} from "./rooms"
@@ -86,10 +86,10 @@ export function isCurrentUserAdminOrMod(room: Room): boolean {
 
 export async function getRoomAdminsAndModerators(
   room: Room
-): Promise<RosterUserProps[]> {
+): Promise<RosterUserData[]> {
   const allMembers = await room.client.getJoinedRoomMembers(room.roomId)
   const userPowerLevels = getRoomUsersIdWithPowerLevels(room)
-  const adminsOrModerators: RosterUserProps[] = []
+  const adminsOrModerators: RosterUserData[] = []
 
   for (const user of userPowerLevels) {
     if (user.powerLevel === UserPowerLevel.Member) {
@@ -102,17 +102,13 @@ export async function getRoomAdminsAndModerators(
       continue
     }
 
-    const displayName = normalizeName(member.display_name ?? user.userId)
     const lastPresenceAge = await getUserLastPresence(room, user.userId)
 
     adminsOrModerators.push({
-      displayName,
+      displayName: normalizeName(member.display_name),
       lastPresenceAge: lastPresenceAge ?? undefined,
       powerLevel: user.powerLevel,
       userId: user.userId,
-      onClick: () => {
-        throw new Error("Roster user click not handled.")
-      },
       avatarUrl: getImageUrl(
         member.avatar_url,
         room.client,

--- a/src/utils/menu.ts
+++ b/src/utils/menu.ts
@@ -72,9 +72,8 @@ export function buildMessageMenuItems({
 }: BuildMessageTemplate): ContextMenuItem[] {
   const menuItems: ContextMenuItem[] = []
 
+  // If is a message error, should not have context items.
   if (isMessageError) {
-    // If is a message error, should not have context items.
-
     return []
   }
 

--- a/src/utils/rooms.ts
+++ b/src/utils/rooms.ts
@@ -158,12 +158,14 @@ export function getPartnerUserIdFromRoomDirect(room: Room): string {
   return userId
 }
 
+const SCROLLBACK_MAX = 30
+
 // #region Events
 export const handleRoomEvents = async (
   activeRoom: Room
 ): Promise<AnyMessage[]> => {
   const client = activeRoom.client
-  const roomHistory = await client.scrollback(activeRoom, 30)
+  const roomHistory = await client.scrollback(activeRoom, SCROLLBACK_MAX)
   const events = roomHistory.getLiveTimeline().getEvents()
   const lastReadEventId = activeRoom.getEventReadUpTo(activeRoom.myUserId)
   const allMessageProperties: AnyMessage[] = []
@@ -195,7 +197,7 @@ export const handleEvent = async (
   room: Room
 ): Promise<AnyMessage | null> => {
   if (event.getType() === EventType.RoomMessage) {
-    return await handleMessages(event, room)
+    return await handleMessage(event, room)
   }
 
   const eventMessageData = await handleEventMessage(event)
@@ -543,7 +545,7 @@ export const handleRoomNameEvent = async (
   }
 }
 
-export const handleMessages = async (
+export const handleMessage = async (
   event: MatrixEvent,
   room: Room
 ): Promise<AnyMessage | null> => {

--- a/src/utils/spaces.ts
+++ b/src/utils/spaces.ts
@@ -51,17 +51,13 @@ export async function getRoomsFromSpace(
         continue
       }
 
-      if (room.isSpaceRoom()) {
-        continue
-      }
-
       roomsHierarchy.push({
         roomId: room.roomId,
         roomName: room.name,
+        emoji: emojiRandom(),
         type: directRoomIds.includes(room.roomId)
           ? RoomType.Direct
           : RoomType.Group,
-        emoji: emojiRandom(),
       })
     }
   } catch (error) {

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -245,15 +245,15 @@ export async function createSpace(
   })
 }
 
-export const emojiRandom = (): string => {
-  const emojiRanges: Array<[number, number]> = [
-    [0x1_f6_00, 0x1_f6_4f], // Emoticons
-    [0x1_f6_80, 0x1_f6_ff], // Transport and Map Symbols
-    [0x26_00, 0x26_ff], // Miscellaneous Symbols
-    [0x27_00, 0x27_bf], // Dingbats
-    [0x1_f9_00, 0x1_f9_ff], // Supplemental Symbols and Pictographs
-  ]
+const emojiRanges: Array<[number, number]> = [
+  [0x1_f6_00, 0x1_f6_4f], // Emoticons
+  [0x1_f6_80, 0x1_f6_ff], // Transport and Map Symbols
+  [0x26_00, 0x26_ff], // Miscellaneous Symbols
+  [0x27_00, 0x27_bf], // Dingbats
+  [0x1_f9_00, 0x1_f9_ff], // Supplemental Symbols and Pictographs
+]
 
+export const emojiRandom = (): string => {
   const [start, end] =
     emojiRanges[Math.floor(Math.random() * emojiRanges.length)]
 


### PR DESCRIPTION
## Mejorar el control de props de mensajes

### Progress:

 - [x] En lugar de pasar props directas al componente desde abajo, pasamos solo datos.
 - [x] Las funciones de cada componente las tratamos en funciones superior en lugar de pasar funciones hacia abajo.
 - [x] Refactorizar y eliminar codigo redundante.
