### PR TITLE
feat: Update `useConnection` and matrix handling

### DIFF
--- a/src/components/AvatarUploader.tsx
+++ b/src/components/AvatarUploader.tsx
@@ -1,10 +1,10 @@
-import useConnection from "@/hooks/matrix/useConnection"
 import {uploadImageToMatrix} from "@/utils/util"
 import {useEffect, useState, type FC} from "react"
 import {IoCamera, IoTrashBin} from "react-icons/io5"
 import {twMerge} from "tailwind-merge"
 import {useFilePicker} from "use-file-picker"
 import Typography, {TypographyVariant} from "./Typography"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 
 type UploadAvatarProps = {
   onAvatarUploaded: (matrixSrc: string) => void
@@ -17,7 +17,7 @@ const AvatarUploader: FC<UploadAvatarProps> = ({
   onAvatarUploaded,
   className,
 }) => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const [isImageUploading, setIsImageUploading] = useState(false)
   const [imagePercent, setImagePercent] = useState(0)
 

--- a/src/components/CreateSpaceModal.tsx
+++ b/src/components/CreateSpaceModal.tsx
@@ -3,14 +3,14 @@ import Typography, {TypographyVariant} from "./Typography"
 import InputSection from "./InputSection"
 import {createSpace} from "@/utils/util"
 import InputArea from "./InputArea"
-import useConnection from "@/hooks/matrix/useConnection"
 import {EventType} from "matrix-js-sdk"
 import AvatarUploader from "./AvatarUploader"
 import useActiveModalStore from "@/hooks/util/useActiveModal"
 import Modal from "./Modal"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 
 const CreateSpaceModal: FC = () => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const [spaceName, setSpaceName] = useState("")
   const [spaceDescription, setSpaceDescription] = useState("")
   const [spaceAvatarUrl, setSpaceAvatarUrl] = useState<string>()

--- a/src/components/SmartActionBar.tsx
+++ b/src/components/SmartActionBar.tsx
@@ -1,5 +1,5 @@
 import SmartAction from "@/components/SmartAction"
-import useConnection from "@/hooks/matrix/useConnection"
+import {useClientStore} from "@/hooks/matrix/useConnection"
 import {SyncState} from "matrix-js-sdk"
 import {type FC} from "react"
 import {IoMdMedical} from "react-icons/io"
@@ -15,7 +15,7 @@ const syncStateText: {[key in SyncState]: string} = {
 }
 
 const SmartActionBar: FC<{className?: string}> = ({className}) => {
-  const {syncState} = useConnection()
+  const {syncState} = useClientStore()
 
   return (
     <div className={className}>

--- a/src/containers/NavigationSection/hooks/useNotifications.ts
+++ b/src/containers/NavigationSection/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 import {type NotificationProps} from "@/components/Notification"
-import useConnection from "@/hooks/matrix/useConnection"
 import useEventListener from "@/hooks/matrix/useEventListener"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 import {getRoomPowerLevelByUserId, UserPowerLevel} from "@/utils/members"
 import {
   getPowerLevelsHistory,
@@ -32,7 +32,7 @@ type UseNotificationsReturnType = {
 }
 
 const useNotifications = (): UseNotificationsReturnType => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
 
   const [notificationsState, setNotificationsState] = useState(
     NotificationState.Waiting

--- a/src/containers/NavigationSection/hooks/useSpaces.ts
+++ b/src/containers/NavigationSection/hooks/useSpaces.ts
@@ -31,7 +31,7 @@ type UseSpacesReturnType = {
 
 const useSpaces = (): UseSpacesReturnType => {
   const client = useMatrixClient()
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
 
   const {
     items: spaces,
@@ -52,32 +52,28 @@ const useSpaces = (): UseSpacesReturnType => {
   )
 
   useEffect(() => {
-    const handler = setTimeout(() => {
-      if (client === null) {
-        return
-      }
+    console.log(client === null, "Is client null")
 
-      setIsLoading(true)
+    if (client === null) {
+      return
+    }
 
-      try {
-        for (const room of client.getRooms()) {
-          if (!room.isSpaceRoom()) {
-            continue
-          }
-
-          addSpace(processSpace(room))
+    try {
+      for (const room of client.getRooms()) {
+        if (!room.isSpaceRoom()) {
+          continue
         }
-      } catch (error) {
-        // TODO: Show toast when error ocurred.
 
-        console.error("Error fetching spaces", error)
+        addSpace(processSpace(room))
       }
 
       setIsLoading(false)
-    }, 1000)
+    } catch (error) {
+      // TODO: Show toast when error ocurred.
 
-    return () => {
-      clearTimeout(handler)
+      console.error("Error fetching spaces", error)
+
+      setIsLoading(false)
     }
   }, [addSpace, client])
 
@@ -116,7 +112,7 @@ const useSpaces = (): UseSpacesReturnType => {
     deleteSpaceWhen(spaceIter => spaceIter.spaceId === room.roomId)
   })
 
-  return {spaces, onSpaceExit, isLoading: isLoading || client === null}
+  return {spaces, onSpaceExit, isLoading}
 }
 
 export default useSpaces

--- a/src/containers/NavigationSection/hooks/useSpaces.ts
+++ b/src/containers/NavigationSection/hooks/useSpaces.ts
@@ -1,10 +1,10 @@
 import {useCallback, useEffect, useState} from "react"
 import useList from "../../../hooks/util/useList"
-import useConnection from "../../../hooks/matrix/useConnection"
 import useEventListener from "@/hooks/matrix/useEventListener"
 import {EventType, type Room, RoomEvent} from "matrix-js-sdk"
 import {KnownMembership} from "matrix-js-sdk/lib/@types/membership"
 import {getImageUrl} from "@/utils/util"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 
 export type PartialSpace = {
   name: string
@@ -30,7 +30,7 @@ type UseSpacesReturnType = {
 }
 
 const useSpaces = (): UseSpacesReturnType => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const [isLoading, setIsLoading] = useState(false)
 
   const {

--- a/src/containers/NavigationSection/hooks/useUserData.ts
+++ b/src/containers/NavigationSection/hooks/useUserData.ts
@@ -1,4 +1,4 @@
-import useConnection from "@/hooks/matrix/useConnection"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 import useLocalStorage, {LocalStorageKey} from "@/hooks/util/useLocalStorage"
 import {cleanDisplayName, type Credentials, getImageUrl} from "@/utils/util"
 import {useCallback, useEffect, useState} from "react"
@@ -22,7 +22,7 @@ type UseUserDataReturnType = {
 }
 
 const useUserData = (): UseUserDataReturnType => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const [userDataState, setUserDataState] = useState(UserDataState.Loading)
 
   const {value: credentials} = useLocalStorage<Credentials>(

--- a/src/containers/NavigationSection/modals/DirectMessageModal.tsx
+++ b/src/containers/NavigationSection/modals/DirectMessageModal.tsx
@@ -6,7 +6,6 @@ import {
   stringToColor,
   formatTime,
 } from "@/utils/util"
-import useConnection from "@/hooks/matrix/useConnection"
 import useInvitationLink from "@/hooks/matrix/useInvitationLink"
 import useUsersSearch from "@/hooks/matrix/useUserSearch"
 import {getDirectRoomsIds, getPartnerUserIdFromRoomDirect} from "@/utils/rooms"
@@ -17,6 +16,7 @@ import Input from "@/components/Input"
 import useActiveModalStore from "@/hooks/util/useActiveModal"
 import {AvatarType} from "@/components/AvatarImage"
 import {motion} from "framer-motion"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 
 type DirectChatRecentProps = {
   userId: string
@@ -51,7 +51,7 @@ const DirectChatRecent: FC<DirectChatRecentProps> = ({
 }
 
 const DirectMessageModal: FC = () => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const {clearActiveModal} = useActiveModalStore()
   const [userId, setUserId] = useState<string | null>(null)
   const [directChats, setDirectChats] = useState<DirectChatRecentProps[]>([])

--- a/src/containers/RoomContainer/RoomInvitedSplash.tsx
+++ b/src/containers/RoomContainer/RoomInvitedSplash.tsx
@@ -3,9 +3,9 @@ import Button, {ButtonVariant} from "@/components/Button"
 import Typography, {TypographyVariant} from "@/components/Typography"
 import {useMemo, useState, type FC} from "react"
 import RoomNotFoundSplash from "./RoomNotFoundSplash"
-import useConnection from "@/hooks/matrix/useConnection"
 import useActiveRoomIdStore from "@/hooks/matrix/useActiveRoomIdStore"
 import {getImageUrl} from "@/utils/util"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 
 enum ActionTypes {
   Join,
@@ -13,7 +13,7 @@ enum ActionTypes {
 }
 
 const RoomInvitedSplash: FC<{roomId: string | null}> = ({roomId}) => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const {setActiveRoomId, clearActiveRoomId} = useActiveRoomIdStore()
   const [actionLoading, setActionLoading] = useState<ActionTypes | null>(null)
   const [error, setError] = useState<string | null>(null)

--- a/src/containers/RoomContainer/hooks/useActiveRoom.ts
+++ b/src/containers/RoomContainer/hooks/useActiveRoom.ts
@@ -1,9 +1,9 @@
-import useConnection from "@/hooks/matrix/useConnection"
 import useActiveRoomIdStore from "@/hooks/matrix/useActiveRoomIdStore"
 import {useEffect, useState} from "react"
 import {KnownMembership} from "matrix-js-sdk/lib/@types/membership"
 import {type MatrixClient, RoomMemberEvent} from "matrix-js-sdk"
 import useEventListener from "@/hooks/matrix/useEventListener"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 
 export enum RoomState {
   Idle,
@@ -19,7 +19,7 @@ type UseActiveRoomReturnType = {
 }
 
 const useActiveRoom = (): UseActiveRoomReturnType => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const [roomState, setRoomState] = useState(RoomState.Idle)
   const {activeRoomId, clearActiveRoomId} = useActiveRoomIdStore()
 

--- a/src/containers/RoomContainer/hooks/useRoomChat.tsx
+++ b/src/containers/RoomContainer/hooks/useRoomChat.tsx
@@ -8,8 +8,8 @@ import {type TypingIndicatorUser} from "@/components/TypingIndicator"
 import {type UnreadIndicatorProps} from "@/components/UnreadIndicator"
 import {type VideoMessageData} from "@/components/VideoMessage"
 import useActiveRoomIdStore from "@/hooks/matrix/useActiveRoomIdStore"
-import useConnection from "@/hooks/matrix/useConnection"
 import useEventListener from "@/hooks/matrix/useEventListener"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 import useRoomListener from "@/hooks/matrix/useRoomListener"
 import useIsMountedRef from "@/hooks/util/useIsMountedRef"
 import {handleRoomMessageEvent, handleRoomEvents} from "@/utils/rooms"
@@ -75,7 +75,7 @@ type UseRoomChatReturnType = {
 }
 
 const useRoomChat = (roomId: string): UseRoomChatReturnType => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const isMountedReference = useIsMountedRef()
   const {clearActiveRoomId} = useActiveRoomIdStore()
 

--- a/src/containers/RoomContainer/useChatInput.ts
+++ b/src/containers/RoomContainer/useChatInput.ts
@@ -1,10 +1,10 @@
-import useConnection from "@/hooks/matrix/useConnection"
 import useDebounced from "@/hooks/util/useDebounced"
 import {sendImageMessageFromFile} from "@/utils/util"
 import {MsgType} from "matrix-js-sdk"
 import {useEffect, useMemo, useState} from "react"
 import {useFilePicker} from "use-file-picker"
 import {type ImageModalPreviewProps} from "./ImageModalPreview"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 
 type UseChatInputReturnType = {
   messageText: string
@@ -17,7 +17,7 @@ type UseChatInputReturnType = {
 }
 
 const useChatInput = (roomId: string): UseChatInputReturnType => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const [messageText, setMessageText] = useState("")
   const debouncedText = useDebounced(messageText, 500)
 

--- a/src/containers/Roster/hooks/useRoomMembers.ts
+++ b/src/containers/Roster/hooks/useRoomMembers.ts
@@ -4,7 +4,7 @@ import {getRoomMembers} from "@/utils/rooms"
 import {type MemberSection} from "@/containers/Roster/MemberList"
 import {type Room} from "matrix-js-sdk"
 import {UserPowerLevel} from "@/utils/members"
-import useConnection from "@/hooks/matrix/useConnection"
+import useMatrixClient from "@/hooks/matrix/useMatrixClient"
 
 export type UseRoomMembersReturnType = {
   sections: MemberSection[]
@@ -19,7 +19,7 @@ enum MembersState {
 }
 
 const useRoomMembers = (roomId: string): UseRoomMembersReturnType => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const isMountedReference = useIsMountedRef()
   const [sections, setSections] = useState<MemberSection[]>([])
   const [membersState, setMembersState] = useState(MembersState.Idle)

--- a/src/hooks/matrix/useConnection.ts
+++ b/src/hooks/matrix/useConnection.ts
@@ -120,7 +120,7 @@ const useConnection = (): UseConnectionReturnType => {
 
         void newClient.startClient({
           lazyLoadMembers: true,
-          initialSyncLimit: 1,
+          resolveInvitesToProfiles: true,
         })
       })
     },

--- a/src/hooks/matrix/useConnection.ts
+++ b/src/hooks/matrix/useConnection.ts
@@ -6,7 +6,7 @@ import {
   SyncState,
   LocalStorageCryptoStore,
 } from "matrix-js-sdk"
-import {useCallback} from "react"
+import {useCallback, useEffect} from "react"
 import {create} from "zustand"
 
 type ZustandClientStore = {
@@ -62,6 +62,29 @@ const useConnection = (): UseConnectionReturnType => {
     lastSyncError,
     setLastSyncError,
   } = useClientStore()
+
+  useEffect(() => {
+    if (client === null) {
+      return
+    }
+
+    const handleSyncState = (
+      newSyncState: SyncState,
+      previousSyncState: SyncState | null
+    ): void => {
+      if (previousSyncState === newSyncState) {
+        return
+      }
+
+      setSyncState(newSyncState)
+    }
+
+    client.on(ClientEvent.Sync, handleSyncState)
+
+    return () => {
+      client.removeListener(ClientEvent.Sync, handleSyncState)
+    }
+  }, [client, setSyncState])
 
   const connect = useCallback(
     async (credentials: Credentials): Promise<boolean> => {

--- a/src/hooks/matrix/useConnection.ts
+++ b/src/hooks/matrix/useConnection.ts
@@ -20,7 +20,7 @@ type ZustandClientStore = {
   setLastSyncError: (error: Error | null) => void
 }
 
-const useClientStore = create<ZustandClientStore>(set => ({
+export const useClientStore = create<ZustandClientStore>(set => ({
   client: null,
   syncState: null,
   lastSyncError: null,

--- a/src/hooks/matrix/useCreateRoom.ts
+++ b/src/hooks/matrix/useCreateRoom.ts
@@ -1,8 +1,8 @@
 import {Visibility, Preset} from "matrix-js-sdk"
 import {useState} from "react"
-import useConnection from "./useConnection"
 import usePublicRoomsSearch from "./usePublicRoomsSearch"
 import useActiveModalStore from "../util/useActiveModal"
+import useMatrixClient from "./useMatrixClient"
 
 // Initial event that declares the room as encrypted.
 const ROOM_ENCRYPTION_OBJECT = {
@@ -36,7 +36,7 @@ const useCreateRoom = (): UseCreateRoomReturnType => {
 
   const [isCreatingRoom, setIsCreatingRoom] = useState(false)
   const {clearActiveModal} = useActiveModalStore()
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const {results, setRoomAddress, roomAddress} = usePublicRoomsSearch(client)
 
   const onCreateRoom = (): void => {

--- a/src/hooks/matrix/useCreateRoom.ts
+++ b/src/hooks/matrix/useCreateRoom.ts
@@ -37,7 +37,9 @@ const useCreateRoom = (): UseCreateRoomReturnType => {
   const [isCreatingRoom, setIsCreatingRoom] = useState(false)
   const {clearActiveModal} = useActiveModalStore()
   const client = useMatrixClient()
-  const {results, setRoomAddress, roomAddress} = usePublicRoomsSearch(client)
+
+  const {results, setRoomAddress, roomAddress, isResultLoading} =
+    usePublicRoomsSearch(client)
 
   const onCreateRoom = (): void => {
     if (client === null) {
@@ -78,11 +80,11 @@ const useCreateRoom = (): UseCreateRoomReturnType => {
     roomVisibility,
     enableEncryption,
     clearActiveModal,
-    isValidAlias: !(results !== null && results.length > 0),
+    isValidAlias: isResultLoading || (results !== null && results.length === 0),
     isDisabled:
       client === null ||
-      roomName.length <= 0 ||
-      (roomVisibility === Visibility.Public && roomAddress.length <= 0),
+      roomName.length === 0 ||
+      (roomVisibility === Visibility.Public && roomAddress.length === 0),
   }
 }
 

--- a/src/hooks/matrix/useEventListener.ts
+++ b/src/hooks/matrix/useEventListener.ts
@@ -1,4 +1,3 @@
-import useConnection from "@/hooks/matrix/useConnection"
 import {
   type EmittedEvents,
   type MatrixEvent,
@@ -8,6 +7,7 @@ import {
   type EventEmitterEvents,
 } from "matrix-js-sdk"
 import {useEffect} from "react"
+import useMatrixClient from "./useMatrixClient"
 
 export type MatrixEventCallback<Return = void> = (
   event: MatrixEvent,
@@ -20,7 +20,7 @@ function useEventListener<Event extends EmittedEvents | EventEmitterEvents>(
   listener: Listener<EmittedEvents, ClientEventHandlerMap, Event>,
   isContinuous = true
 ): void {
-  const {client} = useConnection()
+  const client = useMatrixClient()
 
   useEffect(() => {
     if (client === null) {

--- a/src/hooks/matrix/useMatrixAction.ts
+++ b/src/hooks/matrix/useMatrixAction.ts
@@ -1,11 +1,11 @@
 import {type MatrixClient} from "matrix-js-sdk"
-import useConnection from "./useConnection"
 import {useCallback} from "react"
+import useMatrixClient from "./useMatrixClient"
 
 function useMatrixAction<T>(
   action: (client: MatrixClient) => Promise<T> | T
 ): (() => Promise<T | null>) | null {
-  const {client} = useConnection()
+  const client = useMatrixClient()
 
   const perform = useCallback(async () => {
     if (client === null) {

--- a/src/hooks/matrix/useMatrixClient.ts
+++ b/src/hooks/matrix/useMatrixClient.ts
@@ -1,0 +1,15 @@
+import {useClientStore} from "./useConnection"
+import {type MatrixClient, SyncState} from "matrix-js-sdk"
+
+const useMatrixClient = (): MatrixClient | null => {
+  const {client, isConnecting, syncState} = useClientStore()
+
+  return client === null ||
+    isConnecting ||
+    syncState !== SyncState.Prepared ||
+    !client.isLoggedIn()
+    ? null
+    : client
+}
+
+export default useMatrixClient

--- a/src/hooks/matrix/usePublicRoomsSearch.ts
+++ b/src/hooks/matrix/usePublicRoomsSearch.ts
@@ -3,6 +3,7 @@ import useDebounced from "../util/useDebounced"
 import {type IPublicRoomsChunkRoom, type MatrixClient} from "matrix-js-sdk"
 
 type UsePublicRoomsSearch = {
+  isResultLoading: boolean
   roomAddress: string
   results: IPublicRoomsChunkRoom[] | null
   setRoomAddress: React.Dispatch<React.SetStateAction<string>>
@@ -15,6 +16,7 @@ const usePublicRoomsSearch = (
   const [roomAddress, setRoomAddress] = useState("")
   const debouncedAddress = useDebounced(roomAddress, searchDelay)
   const [results, setResult] = useState<IPublicRoomsChunkRoom[] | null>(null)
+  const [isResultLoading, setResultIsLoading] = useState(false)
 
   useEffect(() => {
     const search = async (): Promise<void> => {
@@ -25,6 +27,8 @@ const usePublicRoomsSearch = (
       }
 
       try {
+        setResultIsLoading(true)
+
         const response = await client.publicRooms({
           filter: {
             generic_search_term: debouncedAddress,
@@ -39,12 +43,14 @@ const usePublicRoomsSearch = (
 
         setResult(null)
       }
+
+      setResultIsLoading(false)
     }
 
     void search()
   }, [client, debouncedAddress])
 
-  return {results, setRoomAddress, roomAddress}
+  return {results, setRoomAddress, roomAddress, isResultLoading}
 }
 
 export default usePublicRoomsSearch

--- a/src/hooks/matrix/useSpaceHierarchy.ts
+++ b/src/hooks/matrix/useSpaceHierarchy.ts
@@ -1,10 +1,10 @@
 import {type RoomType} from "@/components/Room"
 import {useCallback, useEffect, useState} from "react"
-import useConnection from "./useConnection"
 import {getAllJoinedRooms} from "@/utils/rooms"
 import {getRoomsFromSpace} from "@/utils/spaces"
 import {type Room, RoomEvent, type MatrixClient, EventType} from "matrix-js-sdk"
 import useRoomListener from "./useRoomListener"
+import useMatrixClient from "./useMatrixClient"
 
 export enum RoomsState {
   Loaded,
@@ -29,7 +29,7 @@ type UseSpaceHierarchyReturnType = {
 const useSpaceHierarchy = (
   spaceId: string | undefined
 ): UseSpaceHierarchyReturnType => {
-  const {client} = useConnection()
+  const client = useMatrixClient()
   const [roomsState, setRoomsState] = useState(RoomsState.Loading)
   const [rooms, setRooms] = useState<PartialRoom[]>([])
   const [activeSpace, setActiveSpace] = useState<Room | null>(null)

--- a/src/utils/rooms.ts
+++ b/src/utils/rooms.ts
@@ -18,7 +18,7 @@ import {
 } from "./util"
 import {type RosterUserData} from "@/containers/Roster/RosterUser"
 import {
-  getRoomAdminsAndModerators,
+  getRoomUsersIdWithPowerLevels,
   getUserLastPresence,
   isCurrentUserAdminOrMod,
   UserPowerLevel,
@@ -82,35 +82,76 @@ export async function getAllJoinedRooms(
   return currentJoinedRooms
 }
 
+const FETCH_MEMBERS_LIMIT = 30
+const PRESENCE_MAX = 30
+
 export async function getRoomMembers(room: Room): Promise<RosterUserData[]> {
-  const members = await room.client.getJoinedRoomMembers(room.roomId)
-  const adminsOrModerators = await getRoomAdminsAndModerators(room)
-  const joinedMembers = members.joined
-  const membersProperty: RosterUserData[] = adminsOrModerators
+  const membersProperty: RosterUserData[] = []
+  const membersResponse = await room.client.getJoinedRoomMembers(room.roomId)
+  const roomScrollBack = await room.client.scrollback(room, PRESENCE_MAX)
 
-  let memberCount = 0
+  const roomOwnersWithLevels = getRoomUsersIdWithPowerLevels(room).filter(
+    user => user.powerLevel !== UserPowerLevel.Member
+  )
 
-  for (const joinedMemberId in joinedMembers) {
-    if (memberCount >= 30) {
-      break
-    }
+  for (const roomOwner of roomOwnersWithLevels) {
+    const roomOwnerMember = membersResponse.joined[roomOwner.userId]
 
-    const member = joinedMembers[joinedMemberId]
-
-    const isAdminOrModerator = adminsOrModerators.some(
-      adminOrModerator => adminOrModerator.userId === joinedMemberId
-    )
-
-    if (member === undefined || isAdminOrModerator) {
+    if (roomOwnerMember === undefined) {
       continue
     }
 
+    const name = roomOwnerMember.display_name ?? roomOwner.userId
+
+    const lastPresence = await getUserLastPresence(
+      roomScrollBack,
+      PRESENCE_MAX,
+      roomOwner.userId
+    )
+
     membersProperty.push({
-      displayName: normalizeName(member.display_name),
+      displayName: normalizeName(name),
+      powerLevel: roomOwner.powerLevel,
+      userId: roomOwner.userId,
+      lastPresenceAge: lastPresence ?? undefined,
+      avatarUrl: getImageUrl(
+        roomOwnerMember.avatar_url,
+        room.client,
+        ImageSizes.MessageAndProfile
+      ),
+    })
+  }
+
+  let memberCount = 0
+
+  for (const joinedMemberId in membersResponse.joined) {
+    if (memberCount >= FETCH_MEMBERS_LIMIT) {
+      break
+    }
+
+    const member = membersResponse.joined[joinedMemberId]
+
+    const isRoomOwner = roomOwnersWithLevels.some(
+      memberWithLevels => memberWithLevels.userId === joinedMemberId
+    )
+
+    if (member === undefined || isRoomOwner) {
+      continue
+    }
+
+    const name = member.display_name ?? joinedMemberId
+
+    const lastPresence = await getUserLastPresence(
+      roomScrollBack,
+      PRESENCE_MAX,
+      joinedMemberId
+    )
+
+    membersProperty.push({
+      displayName: normalizeName(name),
       powerLevel: UserPowerLevel.Member,
       userId: joinedMemberId,
-      lastPresenceAge:
-        (await getUserLastPresence(room, joinedMemberId)) ?? undefined,
+      lastPresenceAge: lastPresence ?? undefined,
       avatarUrl: getImageUrl(
         member.avatar_url,
         room.client,

--- a/src/views/app.tsx
+++ b/src/views/app.tsx
@@ -1,15 +1,19 @@
 import useConnection from "@/hooks/matrix/useConnection"
 import {type Credentials, ViewPath} from "@/utils/util"
-import {useEffect, type FC} from "react"
+import {useEffect, useState, type FC} from "react"
 import {useNavigate} from "react-router-dom"
 import useLocalStorage, {LocalStorageKey} from "@/hooks/util/useLocalStorage"
 import ModalHandler from "@/components/ModalHandler"
 import RoomContainer from "@/containers/RoomContainer/RoomContainer"
 import NavigationSection from "@/containers/NavigationSection/NavigationSection"
+import Modal from "@/components/Modal"
+import Typography from "@/components/Typography"
+import {motion} from "framer-motion"
 
 const AppView: FC = () => {
   const navigate = useNavigate()
   const {connect} = useConnection()
+  const [connectionError, setConnectionError] = useState(false)
 
   const {value: credentials} = useLocalStorage<Credentials>(
     LocalStorageKey.Credentials
@@ -27,16 +31,38 @@ const AppView: FC = () => {
 
     void connect(credentials).then(async isConnectedAndSynced => {
       if (isConnectedAndSynced) {
+        setConnectionError(false)
+
         return
       }
 
-      // Failed to connect, redirect to login page.
-      navigate(ViewPath.Login)
+      setConnectionError(true)
     })
   }, [connect, credentials, navigate])
 
   return (
     <>
+      {connectionError && (
+        <div className="fixed inset-0 z-50 flex size-full w-screen flex-col items-center justify-center bg-modalOverlay">
+          <motion.div initial={{scale: 0.5}} animate={{scale: 1}}>
+            <Modal
+              title="Connection Error"
+              actionText="Go to login"
+              onAccept={() => {
+                navigate(ViewPath.Login)
+              }}
+              onClose={() => {
+                setConnectionError(false)
+              }}>
+              <Typography>
+                Ops we have lost connection with the server, please reload the
+                page or login again.
+              </Typography>
+            </Modal>
+          </motion.div>
+        </div>
+      )}
+
       <ModalHandler />
 
       <div className="flex size-full flex-row">


### PR DESCRIPTION
## Actualizar funcionalidad de conexion y obtencion de datos de matrix

- [x] Creacion de el hook `useMatrixClient` 
- [x] Reemplazar los `useConnection` por `useMatrixClient` en los lugares que solo necesitan el cliente
- [x] Actualizar obtencion de RoomMembers.
- [x] Gestionar los problemas de conexion.


El hook `useMatrixClient` devuelve unicamente un cliente o un null, el hook por dentro se centra en la devolucion del cliente solo cuando este esta correctamente gestionado, el objetivo de que sea un hook esclusivo para esto es simplemente porque el hook de useConnection es mas dedicado a la conexion, reconexion y obtencion de errores, entonces no tendria sentido llamar a `useConnection` en los distintos componentes ya que traeria codigo innecesario, mejor un hook que se dedique exclusivo a la obtencion de ese cliente en el estado correcto


Con la actualizacion de `useConnection` si de momento se cae la conexion no se quedara la vista pegada de cargando para siempre y te mandara a la pagina de login, esta accion de mandarte a la pagina de login puede ser sustituida por una mejor gestion con Toast cuando estos sean implementados, seria mas sencillo gracias a esta actualizacion de `useConnection`