### PR TITLE
feat: Implement dark mode for `Roster` component

### DIFF
--- a/src/components/UserProfileGhost.tsx
+++ b/src/components/UserProfileGhost.tsx
@@ -30,14 +30,14 @@ const UserProfileGhost: FC<UserProfileGhostProps> = ({
           key={index}
           style={{opacity: 1 - multiplier}}
           className="flex gap-1">
-          <div className="relative size-10 overflow-hidden rounded-lg bg-neutral-300" />
+          <div className="relative size-10 overflow-hidden rounded-lg bg-neutral-300 dark:bg-neutral-800" />
 
           <div className="mr-auto inline-flex flex-col">
-            <div className="overflow-hidden rounded-xl bg-neutral-300 text-profileGhost">
+            <div className="overflow-hidden rounded-xl bg-neutral-300 text-transparent dark:bg-neutral-800">
               Emerald branch
             </div>
 
-            <div className="mt-1 max-h-3 w-min overflow-hidden rounded-xl bg-neutral-300 text-xs text-profileGhost">
+            <div className="mt-1 max-h-3 w-min overflow-hidden rounded-xl bg-neutral-300 text-xs text-transparent dark:bg-neutral-800">
               @emerald
             </div>
           </div>

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -6,25 +6,35 @@ import {cn} from "@/utils/utils"
 interface ScrollAreaProps
   extends React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> {
   isScrollBarHidden?: boolean
+  avoidOverflow?: boolean
 }
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
   ScrollAreaProps
->(({className, isScrollBarHidden, children, ...props}, ref) => (
-  <ScrollAreaPrimitive.Root
-    ref={ref}
-    className={cn("relative overflow-hidden", className)}
-    {...props}>
-    <ScrollAreaPrimitive.Viewport className="size-full rounded-[inherit]">
-      {children}
-    </ScrollAreaPrimitive.Viewport>
+>(
+  (
+    {className, isScrollBarHidden, avoidOverflow = false, children, ...props},
+    ref
+  ) => (
+    <ScrollAreaPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative overflow-hidden",
+        avoidOverflow && "grow basis-0",
+        className
+      )}
+      {...props}>
+      <ScrollAreaPrimitive.Viewport className="size-full rounded-[inherit]">
+        {children}
+      </ScrollAreaPrimitive.Viewport>
 
-    <ScrollBar className={cn(isScrollBarHidden && "hidden")} />
+      <ScrollBar className={cn(isScrollBarHidden && "hidden")} />
 
-    <ScrollAreaPrimitive.Corner />
-  </ScrollAreaPrimitive.Root>
-))
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+)
 
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
 

--- a/src/containers/RoomContainer/RoomContainer.tsx
+++ b/src/containers/RoomContainer/RoomContainer.tsx
@@ -35,7 +35,7 @@ const RoomContainer: FC = () => {
             />
           )}
 
-          <motion.div animate={{width: isRosterExpanded ? 250 : 0}}>
+          <motion.div animate={{width: isRosterExpanded ? "15rem" : 0}}>
             <Roster
               className="max-w-60"
               groupedMembers={groupedMembers}

--- a/src/containers/RoomContainer/RoomContainer.tsx
+++ b/src/containers/RoomContainer/RoomContainer.tsx
@@ -9,6 +9,7 @@ import {ModalRenderLocation} from "@/hooks/util/useActiveModal"
 import useActiveRoom, {RoomState} from "./hooks/useActiveRoom"
 import {motion} from "framer-motion"
 import useRoomMembers from "../Roster/hooks/useRoomMembers"
+import useGlobalHotkey from "@/hooks/util/useGlobalHotkey"
 
 const RoomContainer: FC = () => {
   const {activeRoomId, roomState} = useActiveRoom()
@@ -16,6 +17,10 @@ const RoomContainer: FC = () => {
 
   const {groupedMembers, isMembersLoading, onReloadMembers} =
     useRoomMembers(activeRoomId)
+
+  useGlobalHotkey({key: "M", ctrl: true}, () => {
+    setIsRosterExpanded(prevIsExpanded => !prevIsExpanded)
+  })
 
   return (
     <div

--- a/src/containers/Roster/Roster.tsx
+++ b/src/containers/Roster/Roster.tsx
@@ -1,15 +1,15 @@
 import {type FC} from "react"
 import {IoFilterCircle, IoPeople, IoReloadOutline} from "react-icons/io5"
-import Typography, {TypographyVariant} from "@/components/Typography"
 import {ScrollArea} from "@/components/ui/scroll-area"
 import RosterUser, {type RosterUserData} from "./RosterUser"
 import {twMerge} from "tailwind-merge"
 import {motion} from "framer-motion"
-import {Button} from "@/components/ui/button"
+import {Button, IconButton} from "@/components/ui/button"
 import UserProfileGhost from "@/components/UserProfileGhost"
 import {type GroupedMembers} from "./hooks/useRoomMembers"
 import useTranslation from "@/hooks/util/useTranslation"
 import {LangKey} from "@/lang/allKeys"
+import {Heading, Text} from "@/components/ui/typography"
 
 export enum RosterUserCategory {
   Admin,
@@ -49,38 +49,42 @@ const Roster: FC<RosterProps> = ({
   return (
     <div
       className={twMerge(
-        "flex h-full w-60 flex-col border border-l-slate-300 bg-gray-50",
+        "flex h-full w-60 flex-col border border-l-neutral-300 bg-gray-50 dark:border-l-neutral-600 dark:bg-neutral-900",
         className
       )}>
-      <header className="flex size-full max-h-12 border-b border-b-slate-300">
-        <div className="m-0.5 mx-3 flex w-full items-center justify-center">
-          <IoPeople size={25} className="text-neutral-500" />
+      <header className="flex size-full max-h-12 border-b border-b-neutral-300 dark:border-b-neutral-600">
+        <div className="m-0.5 ml-3 flex w-full items-center justify-center">
+          <IoPeople
+            size={25}
+            className="text-neutral-500 dark:text-neutral-400"
+          />
 
-          <Typography className="ml-1 w-full text-lg text-neutral-600">
+          <Heading
+            level="h5"
+            className="ml-2 w-full text-neutral-600 dark:text-neutral-300">
             {t(LangKey.People)}
-          </Typography>
+          </Heading>
 
-          <Button
+          <IconButton
             aria-label={t(LangKey.SortMembers)}
-            variant="ghost"
-            size="icon"
-            className="size-6 text-neutral-500">
+            tooltip={t(LangKey.SortMembers)}
+            className="text-neutral-500 dark:text-neutral-400">
             <IoFilterCircle size={20} />
-          </Button>
+          </IconButton>
         </div>
       </header>
 
       {hasError ? (
         <div className="flex size-full flex-col items-center justify-center gap-1 p-1">
-          <Typography variant={TypographyVariant.Heading}>
+          <Heading level="h4" align="center">
             {t(LangKey.MembersError)}
-          </Typography>
+          </Heading>
 
           <Button
             aria-label={t(LangKey.ReloadMembers)}
             className="mt-1"
             size="sm"
-            variant="outline"
+            variant="secondary"
             onClick={onReloadMembers}>
             {t(LangKey.ReloadMembers)} <IoReloadOutline className="ml-1" />
           </Button>
@@ -94,7 +98,7 @@ const Roster: FC<RosterProps> = ({
           <RosterSectionSkeleton elementsCount={5} />
         </div>
       ) : (
-        <ScrollArea className="max-w-56 px-1 pt-3" type="scroll">
+        <ScrollArea avoidOverflow className="px-1 pt-3" type="scroll">
           <div className="flex flex-col gap-4">
             <RosterSection
               title={t(LangKey.Admins, admins.length.toString())}
@@ -141,13 +145,15 @@ const RosterSection: FC<{
   return (
     <div className="flex w-full flex-col gap-2.5">
       <motion.div
-        initial={{scale: 0, opacity: 0}}
+        initial={{scale: 0.8, opacity: 0}}
         whileInView={{scale: 1, opacity: 1}}>
-        <Typography
-          variant={TypographyVariant.BodyMedium}
-          className="ml-2 font-medium text-slate-400">
+        <Text
+          size="2"
+          as="label"
+          weight="medium"
+          className="ml-2 text-neutral-500 dark:text-neutral-400">
           {title}
-        </Typography>
+        </Text>
       </motion.div>
 
       <div className="flex w-full flex-col gap-1.5">

--- a/src/containers/Roster/RosterUser.tsx
+++ b/src/containers/Roster/RosterUser.tsx
@@ -1,19 +1,13 @@
 import {type FC} from "react"
-import {stringToColor, formatTime, trim, cleanDisplayName} from "@/utils/util"
+import {stringToColor, formatTime, cleanDisplayName} from "@/utils/util"
 import {twMerge} from "tailwind-merge"
-import Typography, {TypographyVariant} from "@/components/Typography"
 import {type UserPowerLevel} from "@/utils/members"
 import {motion} from "framer-motion"
 import AvatarImage, {AvatarType} from "@/components/AvatarImage"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
 import useTooltip from "@/hooks/util/useTooltip"
 import useTranslation from "@/hooks/util/useTranslation"
 import {LangKey} from "@/lang/allKeys"
+import {TruncatedHeading, TruncatedText} from "@/components/ui/typography"
 
 export type RosterUserData = {
   displayName: string
@@ -47,17 +41,19 @@ const RosterUser: FC<RosterUserProps> = ({
       ? t(LangKey.SeenLongAgo)
       : t(LangKey.LastSeenDate, formatTime(lastPresenceAge))
 
+  const name = displayName.length === 0 ? userId : cleanDisplayName(displayName)
+
   return (
     <motion.button
-      aria-label={`Member: ${displayName}`}
-      initial={{opacity: 0, scale: 0.5}}
+      aria-label={`Member: ${name}`}
+      initial={{opacity: 0, scale: 0.8}}
       whileInView={{opacity: 1, scale: 1}}
       transition={{
         duration: 0.2,
       }}
       ref={renderRef}
       className={twMerge(
-        "flex w-full gap-2 rounded-lg px-2 py-1 hover:bg-gray-100",
+        "flex w-full gap-2 rounded-lg px-2 py-1 hover:bg-gray-200 dark:hover:bg-neutral-800",
         className
       )}
       onClick={() => {
@@ -75,51 +71,27 @@ const RosterUser: FC<RosterUserProps> = ({
         className="shrink-0"
         avatarUrl={avatarUrl}
         avatarType={AvatarType.Profile}
-        displayName={displayName}
+        displayName={name}
         isRounded={false}
       />
 
       <div className="flex w-full flex-col items-start">
-        <RosterUserTypography
+        <TruncatedHeading
+          level="h6"
           style={{color: stringToColor(userId)}}
-          text={displayName.length === 0 ? userId : displayName}
+          text={name}
           maxLength={NAME_MAX_LENGTH}
+          delayDuration={2000}
         />
 
-        <RosterUserTypography
-          variant={TypographyVariant.BodySmall}
+        <TruncatedText
+          size="2"
           text={lastPresence}
           maxLength={USER_ID_MAX_LENGTH}
+          delayDuration={2000}
         />
       </div>
     </motion.button>
-  )
-}
-
-const RosterUserTypography: FC<{
-  text: string
-  maxLength: number
-  variant?: TypographyVariant
-  style?: React.CSSProperties
-}> = ({maxLength, text, style, variant = TypographyVariant.Body}) => {
-  const exceedsLimit = text.length > maxLength
-
-  return exceedsLimit ? (
-    <TooltipProvider delayDuration={2000}>
-      <Tooltip>
-        <TooltipTrigger aria-label={trim(text, maxLength)}>
-          <Typography className="w-max" style={style} variant={variant}>
-            {cleanDisplayName(trim(text, maxLength))}
-          </Typography>
-        </TooltipTrigger>
-
-        <TooltipContent aria-label={text}>{text}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  ) : (
-    <Typography style={style} variant={variant}>
-      {text}
-    </Typography>
   )
 }
 


### PR DESCRIPTION
## Título breve de lo que hiciste

### Progreso:

 - [x] Integrar el componente a la lógica.
 - [x] Implementar aria labels y accesibilidad (key ect...).
 - [x] Verificar responsividad del componente usando dev tools.
 - [x] Crear historia de storybook
 - [x] Agregar hotkeys, tab index y event listeners de Enter para comprobar el componente en el teclado.
 - [x] Agregar variante dark/oscuro para los componentes nuevos creados.


## Si presionas Ctrl + M puedes expandir/contraer el listado de Miembros de una Room

Se soluciono problema de desbordamiento en algunos casos del Roster

![image](https://github.com/user-attachments/assets/08f2acd9-896e-4e85-9862-68bd2049d0ba)

